### PR TITLE
Fix configuration when username or password is not configured

### DIFF
--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -23,11 +23,11 @@ if (!isConnect()) {
 }
 $username = config::byKey("username", "wallbox");
 $password = config::byKey("password", "wallbox");
-if($username == null || $password == null){
+//if($username == null || $password == null){
 ?>
 <p style="color:red;text-align: center;font-weight: bold;">{{Username & Password are required for plugin.}}</p>
 <?php 
-throw new Exception("A username and password is required for the plugin to work"); } ?>
+//throw new Exception("A username and password is required for the plugin to work"); } ?>
 <form class="form-horizontal">
   <fieldset>
     <div class="form-group">


### PR DESCRIPTION
Hello,

I just installed the plugin today but could not configure username and password.

I am not an expert, but I could fix it by commenting 2 lines in configure.php

The if() { is missing the closing }
The error thrown was preventing from displaying the form